### PR TITLE
Optimize ngram proposer for recency bias

### DIFF
--- a/tests/v1/spec_decode/test_ngram.py
+++ b/tests/v1/spec_decode/test_ngram.py
@@ -1,10 +1,42 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import numpy as np
+from dataclasses import dataclass
+import importlib.util
+import pathlib
 
-from vllm.config import ModelConfig, SpeculativeConfig, VllmConfig
-from vllm.v1.spec_decode.ngram_proposer import (
-    NgramProposer, _find_longest_matched_ngram_and_propose_tokens)
+# Import the module directly by path to avoid importing the top-level vllm
+# package (which brings in heavy deps like torch) during unit tests.
+_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_NG_MOD_PATH = _ROOT / "vllm" / "v1" / "spec_decode" / "ngram_proposer.py"
+_spec = importlib.util.spec_from_file_location("_ngram_proposer_mod",
+                                              str(_NG_MOD_PATH))
+_ng_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+assert _spec is not None and _spec.loader is not None
+_spec.loader.exec_module(_ng_mod)
+
+NgramProposer = _ng_mod.NgramProposer
+_find_longest_matched_ngram_and_propose_tokens = (
+    _ng_mod._find_longest_matched_ngram_and_propose_tokens)
+
+
+@dataclass
+class _DummyModelConfig:
+    max_model_len: int = 1024
+
+
+@dataclass
+class _DummySpeculativeConfig:
+    prompt_lookup_min: int
+    prompt_lookup_max: int
+    num_speculative_tokens: int
+    method: str = "ngram"
+
+
+@dataclass
+class _DummyVllmConfig:
+    model_config: _DummyModelConfig
+    speculative_config: _DummySpeculativeConfig
 
 
 def test_find_longest_matched_ngram_and_propose_tokens():
@@ -51,28 +83,29 @@ def test_find_longest_matched_ngram_and_propose_tokens():
                                                        max_model_len=1024,
                                                        k=3),
         np.array([4, 1, 2]))
-    # Return on the first match
+    # Recency bias: when multiple 1-gram matches, pick the most recent prior
     np.testing.assert_array_equal(
         _find_longest_matched_ngram_and_propose_tokens(origin_tokens=tokens,
                                                        min_ngram=1,
                                                        max_ngram=1,
                                                        max_model_len=1024,
-                                                       k=2), np.array([6, 2]))
+                                                       k=2), np.array([4, 1]))
 
 
 def test_ngram_proposer():
 
     def ngram_proposer(min_n: int, max_n: int, k: int) -> NgramProposer:
-        # Dummy model config. Just to set max_model_len.
-        model_config = ModelConfig(model="facebook/opt-125m")
-        return NgramProposer(
-            vllm_config=VllmConfig(model_config=model_config,
-                                   speculative_config=SpeculativeConfig(
-                                       prompt_lookup_min=min_n,
-                                       prompt_lookup_max=max_n,
-                                       num_speculative_tokens=k,
-                                       method="ngram",
-                                   )))
+        # Use lightweight dummy config objects to avoid importing heavy deps.
+        vllm_config = _DummyVllmConfig(
+            model_config=_DummyModelConfig(max_model_len=1024),
+            speculative_config=_DummySpeculativeConfig(
+                prompt_lookup_min=min_n,
+                prompt_lookup_max=max_n,
+                num_speculative_tokens=k,
+                method="ngram",
+            ),
+        )
+        return NgramProposer(vllm_config=vllm_config)  # type: ignore[arg-type]
 
     # No match.
     result = ngram_proposer(
@@ -103,8 +136,8 @@ def test_ngram_proposer():
         context_token_ids=np.array([3, 4, 5, 2, 3, 4, 1, 2, 3, 4]))
     assert np.array_equal(result, np.array([1, 2]))  # Not [5, 2]
 
-    # Multiple 3-gram matched, but always pick the first one.
+    # Multiple 3-gram matched; prefer the most recent prior occurrence.
     result = ngram_proposer(
         min_n=3, max_n=3, k=2).propose(context_token_ids=np.array(
             [1, 2, 3, 100, 1, 2, 3, 200, 1, 2, 3, 300, 1, 2, 3]))
-    assert np.array_equal(result, np.array([100, 1]))
+    assert np.array_equal(result, np.array([300, 1]))

--- a/vllm/v1/spec_decode/ngram_proposer.py
+++ b/vllm/v1/spec_decode/ngram_proposer.py
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import numpy as np
 from numba import jit
 
-from vllm.config import VllmConfig
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
 
 
 class NgramProposer:
 
-    def __init__(self, vllm_config: VllmConfig):
+    def __init__(self, vllm_config: 'VllmConfig'):
         assert vllm_config.speculative_config is not None
         assert vllm_config.speculative_config.prompt_lookup_min is not None
         assert vllm_config.speculative_config.prompt_lookup_max is not None

--- a/vllm/v1/spec_decode/ngram_proposer.py
+++ b/vllm/v1/spec_decode/ngram_proposer.py
@@ -26,18 +26,23 @@ class NgramProposer:
         # Maximum length of the model.
         self.max_model_len = vllm_config.model_config.max_model_len
 
-        # Trigger Numba JIT compilation for N-gram proposer.
-        # This usually takes less than 1 second.
-        self.propose(np.zeros(1024, dtype=np.int32))
+        # Trigger Numba JIT compilation for N-gram proposer with a small
+        # dummy input to warm up and populate cache.
+        self.propose(np.zeros(min(64, self.max_n + 1), dtype=np.int32))
 
     def propose(
         self,
         context_token_ids: np.ndarray,
     ) -> Optional[np.ndarray]:
-        """Proposes the next sequence of tokens based on n-gram pattern 
-        matching in the context. The function finds matches of the last n 
-        tokens in the previous context, and returns k tokens that followed 
-        that match.
+        """Proposes the next sequence of tokens using recency-biased n-gram
+        pattern matching.
+
+        The algorithm looks at up to the last ``prompt_lookup_max`` tokens
+        of the context, finds the longest prior match within the sequence,
+        and proposes up to ``k`` tokens that followed that most recent
+        occurrence of the longest match. If no match is found at that window,
+        it effectively considers smaller n-grams down to
+        ``prompt_lookup_min``.
         
         Args:
             context_token_ids: Numpy array of token IDs representing the 
@@ -54,9 +59,9 @@ class NgramProposer:
             - The last 3 (= max_n) tokens [4,2,3] cannot find a match.
             - The last 2 tokens [2,3] will be matched against the previous 
               4 tokens [1,2,3,4].
-            - Finding a match of [2,3] would return the tokens that 
-              followed that pattern. Here we will return [4,2,3] because 
-              we only have three tokens after the match.
+            - Finding a match of [2,3] returns the tokens that followed the
+              most recent prior match. Here we return [4,2,3] because we only
+              have three tokens after the match.
         """
         # TODO(woosuk): Optimize this.
         return _find_longest_matched_ngram_and_propose_tokens(
@@ -71,15 +76,17 @@ class NgramProposer:
         pass
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def _find_longest_matched_ngram_and_propose_tokens(
         origin_tokens: np.ndarray, min_ngram: int, max_ngram: int,
         max_model_len: int, k: int) -> Optional[np.ndarray]:
     """
-    Find the longest n-gram which matches the suffix of the given tokens
-    whose length is within [min_ngram, max_ngram] (inclusive).
+    Find the longest n-gram that matches the suffix of the given tokens
+    with length in [min_ngram, max_ngram] (inclusive). Among matches of the
+    same length, prefer the most recent prior occurrence (recency bias).
 
-    If found, we will extract k right after the matched ngram.
+    If found, extract up to k tokens that immediately follow the matched
+    n-gram in the context (capped by model length and available tokens).
     """
     # Do not generate draft tokens is context is shorter than minimum n-gram
     total_token = origin_tokens.shape[0]
@@ -91,7 +98,13 @@ def _find_longest_matched_ngram_and_propose_tokens(
     if k <= 0:
         return None
 
-    # Flip tokens, and the goal become to find longest ngram
+    # Effective n-gram upper bound cannot exceed available prior context.
+    # Need at least one prior token to match against.
+    effective_max_ngram = max(0, min(max_ngram, total_token - 1))
+    if effective_max_ngram < min_ngram:
+        return None
+
+    # Flip tokens, and the goal becomes to find the longest n-gram
     # on the rightmost position which matches the prefix with
     # length [min_n, max_n] (inclusive).
     tokens = origin_tokens[::-1]
@@ -100,9 +113,9 @@ def _find_longest_matched_ngram_and_propose_tokens(
     # the current position.
     #   lps[i] = max{v, where tokens[0:v] == tokens[i+1-v:i+1]}
     #
-    # As ngram is capped by max_ngram to save memory, we only need to
-    # store lps for the first max_ngram prefix.
-    lps = np.zeros(max_ngram, dtype=np.int32)
+    # As n-gram is capped by effective_max_ngram to save memory, we only
+    # need to store LPS for the first effective_max_ngram prefix.
+    lps = np.zeros(effective_max_ngram, dtype=np.int32)
 
     longest_ngram = 0
     position = 0
@@ -116,23 +129,26 @@ def _find_longest_matched_ngram_and_propose_tokens(
             # Token match: tokens[:prev_lps+1] is the longest prefix as
             # a suffix of tokens[:i+1]
             prev_lps += 1
-            # Check if we found a longer valid ngram.
+            # Check if we found a longer valid n-gram, or a more recent
+            # occurrence for the same longest length (recency bias).
             #
-            # Update position when longest_ngram matched prev_lps,
-            # as we want to get the target n-gram of the earliest position
-            # in the original tokens (i.e.
-            # latest position in the reversed tokens)
-            if prev_lps >= longest_ngram:
+            # Prefer smaller i (earlier in reversed tokens -> more recent in
+            # original tokens) when lengths tie.
+            if (prev_lps > longest_ngram) or \
+               (prev_lps == longest_ngram and i < position):
                 longest_ngram = prev_lps
                 position = i
-            if i < max_ngram:
-                # Store LPS for the first max_ngram prefix
+            if i < effective_max_ngram:
+                # Store LPS for the first effective_max_ngram prefix
                 lps[i] = prev_lps
-            if prev_lps == max_ngram:
-                # When prev_lps reached max_ngram, update prev_lps
-                # to lps[max_ngram-1] to avoid matching ngram
-                # longer than max_ngram
-                prev_lps = lps[max_ngram - 1]
+            if prev_lps == effective_max_ngram:
+                # We have matched the maximum allowed n-gram length.
+                # This is both the longest possible and, due to the tie-
+                # breaking rule above, the most recent occurrence. We can
+                # early exit by returning the proposal now.
+                start_position = total_token - 1 - i + prev_lps
+                k_out = min(k, total_token - start_position)
+                return origin_tokens[start_position:start_position + k_out]
             i += 1
         elif prev_lps != 0:
             # Token mismatch: try the second longest prefix
@@ -153,5 +169,5 @@ def _find_longest_matched_ngram_and_propose_tokens(
     # is the matched ngram, so we should start drafting tokens from
     # total_token-1-position+longest_ngram
     start_position = total_token - 1 - position + longest_ngram
-    k = min(k, total_token - start_position)
-    return origin_tokens[start_position:start_position + k]
+    k_out = min(k, total_token - start_position)
+    return origin_tokens[start_position:start_position + k_out]


### PR DESCRIPTION
## Purpose

This PR optimizes the N-gram proposer for speculative decoding by introducing a recency bias and enhancing performance.
Specifically, it:
- Modifies the N-gram matching logic to prefer the *most recent* prior occurrence when multiple matches of the same longest length are found.
- Adds an early-exit mechanism once the maximum allowed N-gram length is matched.
- Caps the effective maximum N-gram length based on available context to prevent out-of-bounds access and reduce computation.
- Enables Numba caching for `_find_longest_matched_ngram_and_propose_tokens` to improve subsequent call performance.
- Adjusts the Numba warm-up input size for faster initialization.

## Test Plan

- Unit tests for `_find_longest_matched_ngram_and_propose_tokens` are needed to verify:
    - Correct recency-biased longest match selection.
    - Proper handling of `min_ngram`, `max_ngram`, `k`, and `max_model_len` constraints.
    - Early exit behavior.
- Existing speculative decoding integration tests should be run to ensure no regressions.

## Test Result

- Linter checks passed.
- No specific functional unit or integration test results were generated during this session.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**

---
<a href="https://cursor.com/background-agent?bcId=bc-81731a9e-9f9e-4c1d-b8f1-d82a8f9ee52a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81731a9e-9f9e-4c1d-b8f1-d82a8f9ee52a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

